### PR TITLE
Add a Docker Compose development environment

### DIFF
--- a/DEVELOPING-docker.md
+++ b/DEVELOPING-docker.md
@@ -1,0 +1,78 @@
+# Docker Compose Development Environment
+
+## Install Docker Desktop
+
+To use Docker Compose to run the services required for development, follow the [Getting Started instructions](https://docs.docker.com/get-started/get-docker/).
+
+## Environment settings
+
+Once you have Docker installed, `cp .env.example .env` to make a local copy of the environment settings file, and then edit to supply values for the database:
+
+```
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=metafilter
+DB_USERNAME=metafilter
+DB_PASSWORD=<come up with something>
+```
+
+At this point, you should be able to run `docker compose up` and see logs from the different services (e.g. MySQL, Redis, Mailhog). Or, you can run `docker compose up -d` and the services will start in the background, and you can run `docker compose logs -f <service>` to follow the logs from a specific service.
+
+## Run tool containers
+
+To help work around any differences in the tool versions available on your machine, or even just the lack of installed tools on your machine, there are tool containers that can be run ad-hoc.
+
+ * `composer` - use `docker compose run --rm composer` followed by the arguments for `composer`.
+ * `php artisan` - use `docker compose run --rm artisan` followed by the arguments for `php artisan` (see additional notes below for running `php artisan serve`).
+ * `npm` - use `docker compose run --rm npm` follow by the arguments for `npm`
+ * `mysql` - use `docker compose run --rm mysql mysql -h mysql -u metafilter -p` to access a `mysql` client
+
+## Initial setup
+
+Using the tool containers, run the usual Laravel setup steps:
+
+```
+# composer install
+docker compose run --rm composer install
+
+# npm install
+docker compose run --rm npm install
+
+# npm build
+docker compose run --rm npm build
+
+# php artisan key:generate
+docker compose run --rm artisan key:generate
+
+# php artisan migrate
+docker compose run --rm artisan migrate
+
+# php artisan db:seed
+docker compose run --rm artisan db:seed
+```
+
+## Run development server
+
+Additional options are required to get the right behavior for `php artisan serve`:
+
+```
+docker compose run --rm --service-ports artisan serve --host=0.0.0.0
+```
+
+## Configure test host names
+
+The Laravel app uses hostname routes - i.e. just browsing to `http://localhost:8000` will not show the site. Add the following to `/etc/hosts` so you can browse instead to `http://www.metafilter.test:8000/` and see the right routes:
+
+```
+127.0.0.1   www.metafilter.test
+127.0.0.1   ask.metafilter.test
+127.0.0.1   fanfare.metafilter.test
+127.0.0.1   bestof.metafilter.test
+127.0.0.1   irl.metafilter.test
+127.0.0.1   jobs.metafilter.test
+127.0.0.1   metatalk.metafilter.test
+127.0.0.1   music.metafilter.test
+127.0.0.1   podcast.metafilter.test
+127.0.0.1   projects.metafilter.test
+```

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -42,7 +42,19 @@ final class AppServiceProvider extends ServiceProvider
         ]);
 
         $subdomain = $this->getSubdomain();
-        $subsite = $this->getSubsiteBySubdomain($subdomain);
+        
+        // Skip subsite lookup during database migration in case we're setting up the
+        // schema and the subsites table does not exist yet.
+        if ($this->app->runningInConsole() && 
+            in_array(
+                $_SERVER['argv'][1] ?? null,
+                ['migrate', 'migrate:fresh', 'migrate:refresh', 'migrate:reset', 'migrate:rollback']
+            )
+        ) {
+            $subsite = null;
+        } else {
+            $subsite = $this->getSubsiteBySubdomain($subdomain);
+        }
 
         session([
             'subsite' => $subsite,

--- a/composer.lock
+++ b/composer.lock
@@ -2838,16 +2838,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "cdefacc18993050cdd37e8e980ec66ca4109ae9a"
+                "reference": "0eee8f8eeea4422c279c2622442b2a9a101d558c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/cdefacc18993050cdd37e8e980ec66ca4109ae9a",
-                "reference": "cdefacc18993050cdd37e8e980ec66ca4109ae9a",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/0eee8f8eeea4422c279c2622442b2a9a101d558c",
+                "reference": "0eee8f8eeea4422c279c2622442b2a9a101d558c",
                 "shasum": ""
             },
             "require": {
@@ -2887,20 +2887,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-01-31T11:08:24+00:00"
+            "time": "2025-02-06T11:47:20+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "c92daf4b6e4b478be5d32d5e1b404ba92bb45414"
+                "reference": "407b52ee57feed6f67706af2a18bc81d32aea3f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/c92daf4b6e4b478be5d32d5e1b404ba92bb45414",
-                "reference": "c92daf4b6e4b478be5d32d5e1b404ba92bb45414",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/407b52ee57feed6f67706af2a18bc81d32aea3f1",
+                "reference": "407b52ee57feed6f67706af2a18bc81d32aea3f1",
                 "shasum": ""
             },
             "require": {
@@ -2952,20 +2952,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-01-31T11:08:29+00:00"
+            "time": "2025-02-06T11:47:25+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "8856b3b3714a0efae65d9f817fcc1934b6f34fda"
+                "reference": "6ab0419fd3599aacdd7b2a8f69641cab6f158674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/8856b3b3714a0efae65d9f817fcc1934b6f34fda",
-                "reference": "8856b3b3714a0efae65d9f817fcc1934b6f34fda",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/6ab0419fd3599aacdd7b2a8f69641cab6f158674",
+                "reference": "6ab0419fd3599aacdd7b2a8f69641cab6f158674",
                 "shasum": ""
             },
             "require": {
@@ -3008,11 +3008,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-01-31T11:08:23+00:00"
+            "time": "2025-02-06T11:47:21+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
@@ -3063,7 +3063,7 @@
         },
         {
             "name": "filament/notifications",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
@@ -3115,7 +3115,7 @@
         },
         {
             "name": "filament/spatie-laravel-media-library-plugin",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
@@ -3152,7 +3152,7 @@
         },
         {
             "name": "filament/spatie-laravel-tags-plugin",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-tags-plugin.git",
@@ -3189,7 +3189,7 @@
         },
         {
             "name": "filament/support",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
@@ -3248,16 +3248,16 @@
         },
         {
             "name": "filament/tables",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "1b1d9c3b837c11408ad28240dc9e3e33340d870b"
+                "reference": "d420b0b0cbe605c712ab054a43d51baf5095dc87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/1b1d9c3b837c11408ad28240dc9e3e33340d870b",
-                "reference": "1b1d9c3b837c11408ad28240dc9e3e33340d870b",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/d420b0b0cbe605c712ab054a43d51baf5095dc87",
+                "reference": "d420b0b0cbe605c712ab054a43d51baf5095dc87",
                 "shasum": ""
             },
             "require": {
@@ -3296,11 +3296,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2025-01-31T11:08:58+00:00"
+            "time": "2025-02-06T11:47:34+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v3.2.136",
+            "version": "v3.2.137",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
@@ -10279,24 +10279,24 @@
         },
         {
             "name": "spatie/laravel-honeypot",
-            "version": "4.5.3",
+            "version": "4.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-honeypot.git",
-                "reference": "57727836997ae7351a4f56008bbaf4e2801ce4a0"
+                "reference": "b9bf50effce4c403cd3ac59f69266225498f3a2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-honeypot/zipball/57727836997ae7351a4f56008bbaf4e2801ce4a0",
-                "reference": "57727836997ae7351a4f56008bbaf4e2801ce4a0",
+                "url": "https://api.github.com/repos/spatie/laravel-honeypot/zipball/b9bf50effce4c403cd3ac59f69266225498f3a2e",
+                "reference": "b9bf50effce4c403cd3ac59f69266225498f3a2e",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
-                "illuminate/encryption": "^8.0|^9.0|^10.0|^11.0",
-                "illuminate/http": "^8.0|^9.0|^10.0|^11.0",
-                "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
-                "illuminate/validation": "^8.0|^9.0|^10.0|^11.0",
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/encryption": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/http": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/validation": "^8.0|^9.0|^10.0|^11.0|^12.0",
                 "nesbot/carbon": "^2.0|^3.0",
                 "php": "^8.0",
                 "spatie/laravel-package-tools": "^1.9",
@@ -10304,9 +10304,9 @@
             },
             "require-dev": {
                 "livewire/livewire": "^2.10|^3.0",
-                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
-                "pestphp/pest-plugin-livewire": "^1.0|^2.1",
-                "phpunit/phpunit": "^9.6|^10.5",
+                "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
+                "pestphp/pest-plugin-livewire": "^1.0|^2.1|^3.0",
+                "phpunit/phpunit": "^9.6|^10.5|^11.5",
                 "spatie/pest-plugin-snapshots": "^1.1|^2.1",
                 "spatie/phpunit-snapshot-assertions": "^4.2|^5.1",
                 "spatie/test-time": "^1.2.1"
@@ -10343,7 +10343,7 @@
                 "spatie"
             ],
             "support": {
-                "source": "https://github.com/spatie/laravel-honeypot/tree/4.5.3"
+                "source": "https://github.com/spatie/laravel-honeypot/tree/4.5.4"
             },
             "funding": [
                 {
@@ -10351,7 +10351,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-09-20T13:45:00+00:00"
+            "time": "2025-02-06T11:53:12+00:00"
         },
         {
             "name": "spatie/laravel-livewire-wizard",
@@ -10427,16 +10427,16 @@
         },
         {
             "name": "spatie/laravel-medialibrary",
-            "version": "11.12.2",
+            "version": "11.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-medialibrary.git",
-                "reference": "735127e4d2a61862bd67d0bdfa6ed87528948ace"
+                "reference": "f7ff95dcee59f18bd29187193b02bdb3d746f975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/735127e4d2a61862bd67d0bdfa6ed87528948ace",
-                "reference": "735127e4d2a61862bd67d0bdfa6ed87528948ace",
+                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/f7ff95dcee59f18bd29187193b02bdb3d746f975",
+                "reference": "f7ff95dcee59f18bd29187193b02bdb3d746f975",
                 "shasum": ""
             },
             "require": {
@@ -10520,7 +10520,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-medialibrary/issues",
-                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.12.2"
+                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.12.3"
             },
             "funding": [
                 {
@@ -10532,7 +10532,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-05T08:23:50+00:00"
+            "time": "2025-02-06T11:56:04+00:00"
         },
         {
             "name": "spatie/laravel-model-states",
@@ -10612,27 +10612,27 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.18.3",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "ba67eee37d86ed775dab7dad58a7cbaf9a6cfe78"
+                "reference": "1c9c30ac6a6576b8d15c6c37b6cf23d748df2faa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/ba67eee37d86ed775dab7dad58a7cbaf9a6cfe78",
-                "reference": "ba67eee37d86ed775dab7dad58a7cbaf9a6cfe78",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/1c9c30ac6a6576b8d15c6c37b6cf23d748df2faa",
+                "reference": "1c9c30ac6a6576b8d15c6c37b6cf23d748df2faa",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^9.28|^10.0|^11.0",
+                "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0",
                 "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.5",
-                "orchestra/testbench": "^7.7|^8.0|^9.0",
-                "pestphp/pest": "^1.22|^2",
-                "phpunit/phpunit": "^9.5.24|^10.5",
+                "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.23|^2.1|^3.1",
+                "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
                 "spatie/pest-plugin-test-time": "^1.1|^2.2"
             },
             "type": "library",
@@ -10660,7 +10660,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.18.3"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.19.0"
             },
             "funding": [
                 {
@@ -10668,7 +10668,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-22T08:51:18+00:00"
+            "time": "2025-02-06T14:58:20+00:00"
         },
         {
             "name": "spatie/laravel-permission",
@@ -11769,16 +11769,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v16.5.0",
+            "version": "v16.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "3fb22256317344e049fce02ff289af3b776b0464"
+                "reference": "05c7c3a8a15b1bc396f09d17c88539c0db3d3255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/3fb22256317344e049fce02ff289af3b776b0464",
-                "reference": "3fb22256317344e049fce02ff289af3b776b0464",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/05c7c3a8a15b1bc396f09d17c88539c0db3d3255",
+                "reference": "05c7c3a8a15b1bc396f09d17c88539c0db3d3255",
                 "shasum": ""
             },
             "require": {
@@ -11822,9 +11822,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v16.5.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v16.5.1"
             },
-            "time": "2025-01-27T20:20:33+00:00"
+            "time": "2025-02-07T21:24:29+00:00"
         },
         {
             "name": "symfony/clock",
@@ -14817,16 +14817,16 @@
         },
         {
             "name": "vormkracht10/filament-mails",
-            "version": "v2.2.0",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vormkracht10/filament-mails.git",
-                "reference": "40b536100aaef63612132239b0bccb541af35359"
+                "reference": "f41d248aabe5df63caa6a2bc70a81823989f11f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vormkracht10/filament-mails/zipball/40b536100aaef63612132239b0bccb541af35359",
-                "reference": "40b536100aaef63612132239b0bccb541af35359",
+                "url": "https://api.github.com/repos/vormkracht10/filament-mails/zipball/f41d248aabe5df63caa6a2bc70a81823989f11f7",
+                "reference": "f41d248aabe5df63caa6a2bc70a81823989f11f7",
                 "shasum": ""
             },
             "require": {
@@ -14892,7 +14892,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-23T12:46:49+00:00"
+            "time": "2025-02-07T13:57:45+00:00"
         },
         {
             "name": "vormkracht10/laravel-mails",

--- a/database/seeders/Production/SubsiteSeeder.php
+++ b/database/seeders/Production/SubsiteSeeder.php
@@ -18,7 +18,7 @@ final class SubsiteSeeder extends Seeder
     {
         $subsites = config('metafilter.seeders.subsites');
 
-        foreach ($subsites as $subsite) {
+        foreach ($subsites as $key => $subsite) {
             Subsite::firstOrCreate([
                 'name' => $subsite['name'],
                 'nickname' => $subsite['nickname'] ?? null,
@@ -26,6 +26,7 @@ final class SubsiteSeeder extends Seeder
                 'white_text' => $subsite['white_text'] ?? null,
                 'green_text' => $subsite['green_text'] ?? null,
                 'tagline' => $subsite['tagline'] ?? null,
+                'slug' => $key,
                 'subdomain' => $subsite['subdomain'],
                 'route' => $subsite['route'],
                 'view' => $subsite['view'],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,126 @@
+# Based on https://github.com/aschmelyun/docker-compose-laravel
+networks:
+  metafilter:
+
+services:
+  app:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.nginx
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    platform: linux/amd64
+    ports:
+      - "80:80"
+    volumes:
+      - .:/var/www/html:delegated
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - php
+      - redis
+      - mysql
+      - mailhog
+    networks:
+      - metafilter
+
+  mysql:
+    image: mysql:9
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+    networks:
+      - metafilter
+
+  php:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.php
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    platform: linux/amd64
+    ports:
+      - "9000:9000"
+    volumes:
+      - .:/var/www/html:delegated
+    networks:
+      - metafilter
+
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    networks:
+      - metafilter
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - metafilter
+
+  composer:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.php
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    volumes:
+      - .:/var/www/html:delegated
+    depends_on:
+      - php
+    entrypoint: [ 'composer', '--ignore-platform-reqs' ]
+    profiles:
+      - tools
+    networks:
+      - metafilter
+
+  npm:
+    image: node:current-alpine
+    volumes:
+      - .:/var/www/html
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+      - "5173:5173"
+    working_dir: /var/www/html
+    entrypoint: [ 'npm' ]
+    profiles:
+      - tools
+    networks:
+      - metafilter
+
+  artisan:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.php
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    environment:
+      - DB_HOST=mysql
+      - DB_DATABASE
+      - DB_USERNAME
+      - DB_PASSWORD
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/var/www/html:delegated
+    depends_on:
+      - mysql
+    entrypoint: [ 'php', '/var/www/html/artisan' ]
+    profiles:
+      - tools
+    networks:
+      - metafilter

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,0 +1,18 @@
+FROM nginx:stable-alpine
+
+ARG UID
+ARG GID
+
+ENV UID=${UID}
+ENV GID=${GID}
+
+# MacOS staff group's gid is 20, so is the dialout group in alpine linux. We're not using it, let's just remove it.
+RUN delgroup dialout
+
+RUN addgroup -g ${GID} --system laravel
+RUN adduser -G laravel --system -D -s /bin/sh -u ${UID} laravel
+RUN sed -i "s/user  nginx/user laravel/g" /etc/nginx/nginx.conf
+
+ADD ./nginx/default.conf /etc/nginx/conf.d/
+
+RUN mkdir -p /var/www/html

--- a/docker/Dockerfile.php
+++ b/docker/Dockerfile.php
@@ -1,0 +1,34 @@
+FROM php:8-fpm-alpine
+
+ARG UID
+ARG GID
+
+ENV UID=${UID}
+ENV GID=${GID}
+
+RUN mkdir -p /var/www/html
+
+WORKDIR /var/www/html
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+# MacOS staff group's gid is 20, so is the dialout group in alpine linux. We're not using it, let's just remove it.
+RUN delgroup dialout
+
+RUN addgroup -g ${GID} --system laravel
+RUN adduser -G laravel --system -D -s /bin/sh -u ${UID} laravel
+
+RUN sed -i "s/user = www-data/user = laravel/g" /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i "s/group = www-data/group = laravel/g" /usr/local/etc/php-fpm.d/www.conf
+RUN echo "php_admin_flag[log_errors] = on" >> /usr/local/etc/php-fpm.d/www.conf
+
+RUN docker-php-ext-install pdo pdo_mysql
+
+RUN mkdir -p /usr/src/php/ext/redis \
+    && curl -L https://github.com/phpredis/phpredis/archive/refs/tags/6.1.0.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \
+    && echo 'redis' >> /usr/src/php-available-exts \
+    && docker-php-ext-install redis
+    
+USER laravel
+
+CMD ["php-fpm", "-y", "/usr/local/etc/php-fpm.conf", "-R"]

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,42 @@
+error_log /dev/stdout debug;
+
+server {
+    listen 80;
+    server_name ~^(?<subdomain>\w+)\.metafilter\.test$;
+    root /var/www/html/public_html;
+    
+    index index.php index.html;
+
+    # Handle the subdomain routing
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+    
+    # Pass PHP scripts to PHP-FPM
+    location ~ \.php$ {
+        try_files $uri =404;
+        
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        
+        fastcgi_param HTTP_HOST $host;
+        fastcgi_param SERVER_NAME $host;
+    }
+    
+    # Deny access to .htaccess files
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+# Redirect non-matching domains to www
+server {
+    listen 80;
+    server_name metafilter.test;
+    return 301 $scheme://www.metafilter.test$request_uri;
+}


### PR DESCRIPTION
I ran into some issues on my Mac trying to get all the necessary bits and bobs for PHP running locally, partly because I have pinned other versions of some libraries and tools to support other projects.

This PR adds a Docker Compose environment as this allows building containers for the app services and tools, which can then be independent of the system versions.

The setup is based on https://github.com/aschmelyun/docker-compose-laravel with adjustments for the MetaFilter2024 codebase.

Instructions for using the environment are in DEVELOPING-docker.md.