### PR TITLE
Fix the spacing around the 'Menu' dropdown in the global navigation

### DIFF
--- a/resources/sass/modules/_buttons.scss
+++ b/resources/sass/modules/_buttons.scss
@@ -87,7 +87,8 @@ main > .primary-button {
 
 .main-sidebar,
 .global-navigation button.dropdown-toggle {
-    padding: 0.625rem 1.25rem 0.625rem 0.625rem;
+    padding: 0.625rem 1.735rem 0.625rem 0.625rem;
+    line-height: normal;
     border: none;
     border-radius: 0;
     position: relative;

--- a/resources/sass/modules/_buttons.scss
+++ b/resources/sass/modules/_buttons.scss
@@ -85,7 +85,6 @@ main > .primary-button {
     margin-bottom: 1rem;
 }
 
-.main-sidebar,
 .global-navigation button.dropdown-toggle {
     padding: 0.625rem 1.735rem 0.625rem 0.625rem;
     line-height: normal;

--- a/resources/sass/modules/_layout.scss
+++ b/resources/sass/modules/_layout.scss
@@ -72,6 +72,10 @@ body {
     position: sticky;
     top: 0;
     margin: 0 0 3rem 0;
+    padding: 0.625rem 1.25rem 0.625rem 0.625rem;
+    border: none;
+    border-radius: 0;
+    position: relative;
 }
 
 .main-sidebar section {


### PR DESCRIPTION
As described in #1 

![Screenshot_20250307_113358](https://github.com/user-attachments/assets/6c8b923b-06ea-4b5a-8549-3a460a95c318)
![Screenshot_20250307_113358-highlight](https://github.com/user-attachments/assets/5492c121-08ea-4710-8687-79edd0b64ffb)

The size is also maintained when the search form doesn't break over two lines, which I assume is eventually the plan:

![Screenshot_20250307_113658](https://github.com/user-attachments/assets/5b2a639c-05cd-4511-b03f-490d50553ca6)

**Note:** There were some styles that were being applied to both `.main-sidebar` and `.global-navigation button.dropdown-toggle`. I have split these up and moved the sidebar styles to `_layout.scss` - if these styles were actually meant to be applied to buttons in the sidebar, rather than the sidebar itself, let me know and I can move them back and fix the selector