### PR TITLE
Docker development environment (mk2)

### DIFF
--- a/DEVELOPING-docker.md
+++ b/DEVELOPING-docker.md
@@ -23,10 +23,10 @@ At this point, you should be able to run `docker compose up` and see logs from t
 
 To help work around any differences in the tool versions available on your machine, or even just the lack of installed tools on your machine, there are tool containers that can be run ad-hoc.
 
- * `composer` - use `docker compose run --rm composer` followed by the arguments for `composer`.
- * `php artisan` - use `docker compose run --rm artisan` followed by the arguments for `php artisan` (see additional notes below for running `php artisan serve`).
- * `npm` - use `docker compose run --rm npm` follow by the arguments for `npm`
- * `mysql` - use `docker compose run --rm mysql mysql -h mysql -u metafilter -p` to access a `mysql` client
+-   `composer` - use `docker compose run --rm composer` followed by the arguments for `composer`.
+-   `php artisan` - use `docker compose run --rm artisan` followed by the arguments for `php artisan` (see additional notes below for running `php artisan serve`).
+-   `npm` - use `docker compose run --rm npm` follow by the arguments for `npm`
+-   `mysql` - use `docker compose run --rm mysql mysql -h mysql -u metafilter -p` to access a `mysql` client
 
 ## Initial setup
 
@@ -40,7 +40,7 @@ docker compose run --rm composer install
 docker compose run --rm npm install
 
 # npm build
-docker compose run --rm npm build
+docker compose run --rm npm run build
 
 # php artisan key:generate
 docker compose run --rm artisan key:generate
@@ -62,7 +62,7 @@ docker compose run --rm --service-ports artisan serve --host=0.0.0.0
 
 ## Configure test host names
 
-The Laravel app uses hostname routes - i.e. just browsing to `http://localhost:8000` will not show the site. Add the following to `/etc/hosts` so you can browse instead to `http://www.metafilter.test:8000/` and see the right routes:
+The Laravel app uses hostname routes - i.e. just browsing to `http://localhost` will not show the site. Add the following to `/etc/hosts` so you can browse instead to `http://www.metafilter.test/` and see the right routes:
 
 ```
 127.0.0.1   www.metafilter.test

--- a/DEVELOPING-docker.md
+++ b/DEVELOPING-docker.md
@@ -1,0 +1,78 @@
+# Docker Compose Development Environment
+
+## Install Docker Desktop
+
+To use Docker Compose to run the services required for development, follow the [Getting Started instructions](https://docs.docker.com/get-started/get-docker/).
+
+## Environment settings
+
+Once you have Docker installed, `cp .env.example .env` to make a local copy of the environment settings file, and then edit to supply values for the database:
+
+```
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=metafilter
+DB_USERNAME=metafilter
+DB_PASSWORD=<come up with something>
+```
+
+At this point, you should be able to run `docker compose up` and see logs from the different services (e.g. MySQL, Redis, Mailhog). Or, you can run `docker compose up -d` and the services will start in the background, and you can run `docker compose logs -f <service>` to follow the logs from a specific service.
+
+## Run tool containers
+
+To help work around any differences in the tool versions available on your machine, or even just the lack of installed tools on your machine, there are tool containers that can be run ad-hoc.
+
+ * `composer` - use `docker compose run --rm composer` followed by the arguments for `composer`.
+ * `php artisan` - use `docker compose run --rm artisan` followed by the arguments for `php artisan` (see additional notes below for running `php artisan serve`).
+ * `npm` - use `docker compose run --rm npm` follow by the arguments for `npm`
+ * `mysql` - use `docker compose run --rm mysql mysql -h mysql -u metafilter -p` to access a `mysql` client
+
+## Initial setup
+
+Using the tool containers, run the usual Laravel setup steps:
+
+```
+# composer install
+docker compose run --rm composer install
+
+# npm install
+docker compose run --rm npm install
+
+# npm build
+docker compose run --rm npm build
+
+# php artisan key:generate
+docker compose run --rm artisan key:generate
+
+# php artisan migrate
+docker compose run --rm artisan migrate
+
+# php artisan db:seed
+docker compose run --rm artisan db:seed
+```
+
+## Run development server
+
+Additional options are required to get the right behavior for `php artisan serve`:
+
+```
+docker compose run --rm --service-ports artisan serve --host=0.0.0.0
+```
+
+## Configure test host names
+
+The Laravel app uses hostname routes - i.e. just browsing to `http://localhost:8000` will not show the site. Add the following to `/etc/hosts` so you can browse instead to `http://www.metafilter.test:8000/` and see the right routes:
+
+```
+127.0.0.1   www.metafilter.test
+127.0.0.1   ask.metafilter.test
+127.0.0.1   fanfare.metafilter.test
+127.0.0.1   bestof.metafilter.test
+127.0.0.1   irl.metafilter.test
+127.0.0.1   jobs.metafilter.test
+127.0.0.1   metatalk.metafilter.test
+127.0.0.1   music.metafilter.test
+127.0.0.1   podcast.metafilter.test
+127.0.0.1   projects.metafilter.test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,12 +89,12 @@ services:
   npm:
     image: node:current-alpine
     volumes:
-      - .:/var/www/html
+      - .:/MetaFilter2024
     ports:
       - "3000:3000"
       - "3001:3001"
       - "5173:5173"
-    working_dir: /var/www/html
+    working_dir: /MetaFilter2024
     entrypoint: [ 'npm' ]
     profiles:
       - tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,126 @@
+# Based on https://github.com/aschmelyun/docker-compose-laravel
+networks:
+  metafilter:
+
+services:
+  app:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.nginx
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    platform: linux/amd64
+    ports:
+      - "80:80"
+    volumes:
+      - .:/var/www/html:delegated
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - php
+      - redis
+      - mysql
+      - mailhog
+    networks:
+      - metafilter
+
+  mysql:
+    image: mysql:9
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+    networks:
+      - metafilter
+
+  php:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.php
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    platform: linux/amd64
+    ports:
+      - "9000:9000"
+    volumes:
+      - .:/var/www/html:delegated
+    networks:
+      - metafilter
+
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    networks:
+      - metafilter
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - metafilter
+
+  composer:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.php
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    volumes:
+      - .:/var/www/html:delegated
+    depends_on:
+      - php
+    entrypoint: [ 'composer', '--ignore-platform-reqs' ]
+    profiles:
+      - tools
+    networks:
+      - metafilter
+
+  npm:
+    image: node:current-alpine
+    volumes:
+      - .:/var/www/html
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+      - "5173:5173"
+    working_dir: /var/www/html
+    entrypoint: [ 'npm' ]
+    profiles:
+      - tools
+    networks:
+      - metafilter
+
+  artisan:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.php
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    environment:
+      - DB_HOST=mysql
+      - DB_DATABASE
+      - DB_USERNAME
+      - DB_PASSWORD
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/var/www/html:delegated
+    depends_on:
+      - mysql
+    entrypoint: [ 'php', '/var/www/html/artisan' ]
+    profiles:
+      - tools
+    networks:
+      - metafilter

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,0 +1,18 @@
+FROM nginx:stable-alpine
+
+ARG UID
+ARG GID
+
+ENV UID=${UID}
+ENV GID=${GID}
+
+# MacOS staff group's gid is 20, so is the dialout group in alpine linux. We're not using it, let's just remove it.
+RUN delgroup dialout
+
+RUN addgroup -g ${GID} --system laravel
+RUN adduser -G laravel --system -D -s /bin/sh -u ${UID} laravel
+RUN sed -i "s/user  nginx/user laravel/g" /etc/nginx/nginx.conf
+
+ADD ./nginx/default.conf /etc/nginx/conf.d/
+
+RUN mkdir -p /var/www/html

--- a/docker/Dockerfile.php
+++ b/docker/Dockerfile.php
@@ -1,0 +1,34 @@
+FROM php:8-fpm-alpine
+
+ARG UID
+ARG GID
+
+ENV UID=${UID}
+ENV GID=${GID}
+
+RUN mkdir -p /var/www/html
+
+WORKDIR /var/www/html
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+# MacOS staff group's gid is 20, so is the dialout group in alpine linux. We're not using it, let's just remove it.
+RUN delgroup dialout
+
+RUN addgroup -g ${GID} --system laravel
+RUN adduser -G laravel --system -D -s /bin/sh -u ${UID} laravel
+
+RUN sed -i "s/user = www-data/user = laravel/g" /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i "s/group = www-data/group = laravel/g" /usr/local/etc/php-fpm.d/www.conf
+RUN echo "php_admin_flag[log_errors] = on" >> /usr/local/etc/php-fpm.d/www.conf
+
+RUN docker-php-ext-install pdo pdo_mysql
+
+RUN mkdir -p /usr/src/php/ext/redis \
+    && curl -L https://github.com/phpredis/phpredis/archive/refs/tags/6.1.0.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \
+    && echo 'redis' >> /usr/src/php-available-exts \
+    && docker-php-ext-install redis
+    
+USER laravel
+
+CMD ["php-fpm", "-y", "/usr/local/etc/php-fpm.conf", "-R"]

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,42 @@
+error_log /dev/stdout debug;
+
+server {
+    listen 80;
+    server_name ~^(?<subdomain>\w+)\.metafilter\.test$;
+    root /var/www/html/public_html;
+    
+    index index.php index.html;
+
+    # Handle the subdomain routing
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+    
+    # Pass PHP scripts to PHP-FPM
+    location ~ \.php$ {
+        try_files $uri =404;
+        
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        
+        fastcgi_param HTTP_HOST $host;
+        fastcgi_param SERVER_NAME $host;
+    }
+    
+    # Deny access to .htaccess files
+    location ~ /\.ht {
+        deny all;
+    }
+}
+
+# Redirect non-matching domains to www
+server {
+    listen 80;
+    server_name metafilter.test;
+    return 301 $scheme://www.metafilter.test$request_uri;
+}


### PR DESCRIPTION
I don't have any sort of PHP environment installed locally, and I'm a grubby Windows user, so I needed something to test my various a11y stuff I'm working on.

This PR builds heavily on #2 -@wrose504's PR mostly works, but needed a few tweaks to avoid unnecessarily updating version-controlled files, and to avoid some command errors.  It also doesn't include potentially unrelated code/dependency changes, so may be easier to merge. 

I had toyed with a couple of additional changes, but wanted to keep this small for the time being.  Let me know if you're interested in any of the below:

- Investigate using mDNS/avahi to publish `[site].metafilter.local` domains without needing to modify the hosts file.
- Running the various dev commands still feels really manual and arcane.  Things could be further automated in something like
  - Turn the primary `artisan` command into a watching container, so that a single `docker compose up -d` can run in the background, and simplify startup.
  - Failing that, some scripts to orchestrate initial setup and running the dev environment