### PR TITLE
Only show contact activity to logged in user

### DIFF
--- a/resources/views/layouts/sidebars/metafilter-sidebar.blade.php
+++ b/resources/views/layouts/sidebars/metafilter-sidebar.blade.php
@@ -1,4 +1,6 @@
-@include('layouts.sidebars.partials.contact-activity')
+@auth
+    @include('layouts.sidebars.partials.contact-activity')
+@endauth
 @include('layouts.sidebars.partials.us-politics')
 @include('layouts.sidebars.partials.best-of')
 


### PR DESCRIPTION
## What I did 
- Hide righthand item "Contact Activity" when user is not logged in.

Closes issue [18](https://github.com/MetaFilter/MetaFilter2024/issues/18)