### PR TITLE
Mixedcase email signup

### DIFF
--- a/app/Http/Requests/Signup/StoreEmailAddressRequest.php
+++ b/app/Http/Requests/Signup/StoreEmailAddressRequest.php
@@ -24,7 +24,6 @@ final class StoreEmailAddressRequest extends BaseFormRequest
             'email' => [
                 'required',
                 'string',
-                'lowercase',
                 'email',
                 'max:255',
                 Rule::unique(User::class),

--- a/app/Livewire/Wizards/SignupWizardComponent.php
+++ b/app/Livewire/Wizards/SignupWizardComponent.php
@@ -79,6 +79,7 @@ final class SignupWizardComponent extends BaseWizardComponent
     // Step 3
     public function submitEmailAddress(): void
     {
+        $this->email = strtolower($this->email);
         $rules = (new StoreEmailAddressRequest())->rules();
         \Log::debug('Email: ' . $this->email);
 


### PR DESCRIPTION
Removed form validation enforcing lowercase on the email field-- instead just letting the server-side submission process strtolower() the email data it gets passed.

fixes #16