### PR TITLE
comment contents are stored in 'body' not 'text' fields.

### DIFF
--- a/resources/views/livewire/comments/comment-component.blade.php
+++ b/resources/views/livewire/comments/comment-component.blade.php
@@ -1,5 +1,5 @@
 <article class="comment">
-    {{ $comment->text }}
+    {{ $comment->body }}
 
     <footer class="comment-footer">
         <p>

--- a/resources/views/livewire/comments/comment-show-component.blade.php
+++ b/resources/views/livewire/comments/comment-show-component.blade.php
@@ -1,5 +1,5 @@
 <article class="comment">
-    {{ $comment->text }}
+    {{ $comment->body }}
 
     <footer class="comment-footer">
         <p>


### PR DESCRIPTION
The comment template that gets generated within a post was looking for the `text` field within the `comment` object, but the model uses the `body` field to store that data. 

fixes #21 