### PR TITLE
Limit resize to vertical

### DIFF
--- a/resources/js/wysiwyg.js
+++ b/resources/js/wysiwyg.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const editorConfig = JSON.parse(document.querySelector('meta[name="ckeditor-config"]')?.content || '{}');
 
     document.querySelectorAll('.wysiwyg').forEach(textarea => {
+        textarea.classList.add('comment-textarea');
         ClassicEditor
             .create(textarea, editorConfig)
             .then(editor => {

--- a/resources/sass/modules/_forms.scss
+++ b/resources/sass/modules/_forms.scss
@@ -19,6 +19,10 @@ main input[type='url'] {
     width: 100%;
 }
 
+textarea {
+    resize: block;
+}
+
 input[type='radio'] {
     appearance: none;
     background-color: inherit;

--- a/resources/sass/modules/_forms.scss
+++ b/resources/sass/modules/_forms.scss
@@ -19,7 +19,7 @@ main input[type='url'] {
     width: 100%;
 }
 
-textarea {
+textarea.comment-textarea {
     resize: block;
 }
 

--- a/resources/views/livewire/comments/comment-form-component.blade.php
+++ b/resources/views/livewire/comments/comment-form-component.blade.php
@@ -16,7 +16,7 @@
                 {{ trans('Comment') }}
             </label>
 
-            <textarea wire:model="text" name="text" id="text"></textarea>
+            <textarea wire:model="text" name="text" id="text" class="comment-textarea"></textarea>
 
             <div class="level">
                 @if($isEditing === true || $isReplying === true)

--- a/resources/views/livewire/comments/comment-form.blade.php
+++ b/resources/views/livewire/comments/comment-form.blade.php
@@ -1,5 +1,5 @@
 <form>
     <label for="comment">Comment:</label><br>
-    <textarea id="comment" name="comment" rows="4" cols="50"></textarea><br><br>
+    <textarea id="comment" name="comment" rows="4" cols="50" class="comment-textarea"></textarea><br><br>
     <input type="submit" value="Submit">
 </form>

--- a/resources/views/livewire/comments/edit-comment-component.blade.php
+++ b/resources/views/livewire/comments/edit-comment-component.blade.php
@@ -6,7 +6,7 @@
 
         @if ($isEditing)
             <form wire:submit.prevent="updateComment()">
-                <textarea wire:model="content"></textarea>
+                <textarea wire:model="content" class="comment-textarea"></textarea>
 
                 @error('content')
                     <span class="text-danger">

--- a/resources/views/livewire/comments/reply-to-comment-component.blade.php
+++ b/resources/views/livewire/comments/reply-to-comment-component.blade.php
@@ -1,5 +1,5 @@
     <form>
-        <textarea wire:model="replyText" placeholder="{{ trans('Write your reply') }}&hellip;">
+        <textarea wire:model="replyText" placeholder="{{ trans('Write your reply') }}&hellip;" class="comment-textarea">
 
         </textarea>
 


### PR DESCRIPTION
@kirkaracha this seemed like an easy issue, but the first question it's led me to is - how are you thinking about CSS? Are you planning to set up different classes by component to help keep styles consistent, or is it preferable to add styling directly.

In 9c9bfa3 I just styled all `textarea` elements to be block resizable, but then I thought maybe attaching a dedicated class was a better idea.