### PR TITLE
Fix sidebar elements wrapping

### DIFF
--- a/resources/sass/modules/_layout.scss
+++ b/resources/sass/modules/_layout.scss
@@ -69,23 +69,38 @@ body {
 }
 
 .main-sidebar {
-    position: sticky;
-    top: 0;
-    margin: 0 0 3rem 0;
-    padding: 0.625rem 1.25rem 0.625rem 0.625rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
     border: none;
     border-radius: 0;
     position: relative;
 }
 
-.main-sidebar section {
-    margin: 0 0 1rem 0;
-}
-
 .main-sidebar details {
     position: relative;
-    padding: 3rem 1.5rem 1rem 1.5rem;
+    display: flex;
+    gap: 1rem;
+    flex-direction: column;
+    align-items: stretch;
+    border-radius: 0.33rem;
 }
+
+.main-sidebar details> :not(summary) {
+    padding-inline: 1.5rem;
+}
+
+.main-sidebar details:first-child {
+    border-top-left-radius: 0.33rem;
+    border-top-right-radius: 0.33rem;
+}
+
+.main-sidebar details:last-child {
+    padding-bottom: 1rem;
+    border-bottom-left-radius: 0.33rem;
+    border-bottom-right-radius: 0.33rem;
+}
+
 /*
 // TODO: Figure out minimizing when closed
 .main-sidebar details[open] {
@@ -94,10 +109,7 @@ body {
 */
 
 .main-sidebar summary {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
+    align-items: center;
     padding: 0.5rem;
     border-top-left-radius: 0.33rem;
     border-top-right-radius: 0.33rem;
@@ -133,7 +145,7 @@ body {
     position: relative;
 }
 
-.site-banner > button {
+.site-banner>button {
     position: absolute;
     top: 0;
     right: 0;
@@ -172,9 +184,13 @@ body {
         gap: 4rem;
     }
 
-    .global-navigation .container > ul,
-    .main-contents {
+    .global-navigation .container>ul {
         width: 75%;
+    }
+
+    .main-contents {
+        flex: 1 1 75%;
+        min-width: 25%;
     }
 
     .minimal .main-contents {
@@ -186,9 +202,12 @@ body {
         padding: 1rem 0 0 0;
     }
 
-    .global-navigation .container > search,
-    .main-sidebar {
+    .global-navigation .container>search {
         width: 25%;
+    }
+
+    .main-sidebar {
+        flex: 0 0 25%;
     }
 
     .global-header {

--- a/resources/sass/modules/_sidebar.scss
+++ b/resources/sass/modules/_sidebar.scss
@@ -1,11 +1,6 @@
-
 .main-sidebar section {
     margin: 0 0 1rem 0;
     border-radius: 0.33rem;
-}
-
-.main-sidebar section:last-of-type {
-    margin-bottom: 0;
 }
 
 .main-sidebar section header {

--- a/resources/views/components/today-in-history-component.blade.php
+++ b/resources/views/components/today-in-history-component.blade.php
@@ -9,5 +9,5 @@
         </ul>
     </nav>
 
-    {{ trans('years ago') }}
+    <div class="sidebar-section-content">{{ trans('years ago') }}</div>
 </x-layout.sidebar-section-component>

--- a/resources/views/layouts/sidebars/partials/active.cities.blade.php
+++ b/resources/views/layouts/sidebars/partials/active.cities.blade.php
@@ -2,5 +2,5 @@
     <x-slot name="heading">
         Active Cities
     </x-slot>
-    Active cities
+    <div class="sidebar-section-content">Active cities</div>
 </x-layout.sidebar-section-component>

--- a/resources/views/layouts/sidebars/partials/best-of.blade.php
+++ b/resources/views/layouts/sidebars/partials/best-of.blade.php
@@ -1,3 +1,3 @@
 <x-layout.sidebar-section-component heading="{{  trans('Best Of') }}" open="true">
-    Best Of
+    <div class="sidebar-section-content">Best Of</div>
 </x-layout.sidebar-section-component>

--- a/resources/views/layouts/sidebars/partials/contact-activity.blade.php
+++ b/resources/views/layouts/sidebars/partials/contact-activity.blade.php
@@ -1,3 +1,3 @@
 <x-layout.sidebar-section-component heading="{{  trans('Contact Activity') }}" open="true">
-    Contact activity
+    <div class="sidebar-section-content">Contact activity</div>
 </x-layout.sidebar-section-component>

--- a/resources/views/layouts/sidebars/partials/us-politics.blade.php
+++ b/resources/views/layouts/sidebars/partials/us-politics.blade.php
@@ -1,3 +1,3 @@
 <x-layout.sidebar-section-component heading="{{  trans('US Politics') }}" open="true">
-    {{  trans('US politics') }}
+    <div class="sidebar-section-content">{{  trans('US politics') }}</div>
 </x-layout.sidebar-section-component>


### PR DESCRIPTION
Another PR that is maybe more questions than answers!

I think it's easier to get the sidebar to behave if we don't use absolute positioning for the `summary` elements and instead make the `details` a flex container, with the previous padding distributed across the `summary` and any content elements.

The only restriction this creates is that the content _must_ be in elements, i.e. slots cannot just contain text. I don't know that there's a way to constrain this, though, so I just updated the existing placeholders, but the other way to handle it would be to always add the content to a `div` in the template.

Here's what it looks like when resizing with these changes.

![sidebar resize](https://github.com/user-attachments/assets/118fb07f-f025-4dd8-9829-d2b94216ac7f)
