### PR TITLE
Enable vite HMR

### DIFF
--- a/DEVELOPING-docker.md
+++ b/DEVELOPING-docker.md
@@ -52,14 +52,6 @@ docker compose run --rm artisan migrate
 docker compose run --rm artisan db:seed
 ```
 
-## Run development server
-
-Additional options are required to get the right behavior for `php artisan serve`:
-
-```
-docker compose run --rm --service-ports artisan serve --host=0.0.0.0
-```
-
 ## Configure test host names
 
 The Laravel app uses hostname routes - i.e. just browsing to `http://localhost` will not show the site. Add the following to `/etc/hosts` so you can browse instead to `http://www.metafilter.test/` and see the right routes:
@@ -76,3 +68,11 @@ The Laravel app uses hostname routes - i.e. just browsing to `http://localhost` 
 127.0.0.1   podcast.metafilter.test
 127.0.0.1   projects.metafilter.test
 ```
+
+## Run development server
+
+Start the frontend build server using `docker compose run --rm --service-ports npm run dev`.
+This will start a server on port 5173 that will hot reload on frontend changes.
+
+Start the backend server using `docker compose run --rm --service-ports artisan serve`.
+The development server should then be accessible at http://www.metafilter.test:8000/, with hot reloading on frontend changes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,12 +90,16 @@ services:
     image: node:current-alpine
     volumes:
       - .:/MetaFilter2024
+      - node-modules:/MetaFilter2024/node_modules
     ports:
       - "3000:3000"
       - "3001:3001"
       - "5173:5173"
     working_dir: /MetaFilter2024
     entrypoint: [ 'npm' ]
+    environment:
+      - APP_HOST
+      - VITE_HOST=0.0.0.0
     profiles:
       - tools
     networks:
@@ -113,6 +117,8 @@ services:
       - DB_DATABASE
       - DB_USERNAME
       - DB_PASSWORD
+      - SERVER_HOST=0.0.0.0
+      - SERVER_PORT=8000
     ports:
       - "8000:8000"
     volumes:
@@ -124,3 +130,6 @@ services:
       - tools
     networks:
       - metafilter
+
+volumes:
+  node-modules:

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,25 @@ import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import { resolve } from 'path';
 
+// Get host from command line or use default
+const appHost = process.env.APP_HOST || 'metafilter.test';
+const subdomains = [
+    'www', 
+    'ask', 
+    'metatalk', 
+    'fanfare', 
+    'projects', 
+    'music', 
+    'jobs', 
+    'irl'
+];
+
+// Create allowed hosts list with both bare domain and subdomains
+const allowedHosts = [appHost, ...subdomains.map(sub => `${sub}.${appHost}`)];
+
+// Serve on localhost by default
+const serverHost = process.env.VITE_HOST || 'localhost';
+
 // noinspection JSUnusedGlobalSymbols
 export default defineConfig({
     css: {
@@ -11,6 +30,14 @@ export default defineConfig({
                 api: 'modern-compiler'
             }
         }
+    },
+    server: {
+        host: serverHost,
+        allowedHosts,
+        hmr: { host: serverHost },
+        cors: true,
+        strictPort: true,
+        port: 5173,
     },
     plugins: [
         laravel({
@@ -33,11 +60,14 @@ export default defineConfig({
             ],
             refresh: [
                 'app/Livewire/**',
+                'resources/views/**',
             ],
             publicDirectory: 'public_html',
             build: {
                 outDir: 'public_html/build',
             },
+            // Use specific host configuration
+            host: appHost,
         })
     ],
     resolve: {


### PR DESCRIPTION
This PR enables hot module reloading in Vite so that changes to CSS and JS should propagate immediately (no reload required!) when running the development server.

I tested this in both Docker and outside Docker (i.e. with `docker compose run --rm --service ports npm run dev` and just plain `npm run dev`) and it seems to work in both configurations.
