### PR TITLE
Fix nav button alignment

### DIFF
--- a/resources/sass/modules/_navigation.scss
+++ b/resources/sass/modules/_navigation.scss
@@ -22,13 +22,16 @@ nav ul li {
     display: block;
 }
 
-.dropdown-toggle > img {
+.dropdown-toggle>img {
     pointer-events: none;
 }
 
 .global-header .container {
-    padding: 1rem 0 1rem 0;
     position: relative;
+}
+
+.global-header .container>:not(.utility-navigation) {
+    padding: 1rem 0;
 }
 
 .global-navigation-menu {
@@ -47,7 +50,7 @@ nav ul li {
 
 .utility-navigation {
     position: relative;
-    top: -1.15rem;
+    align-self: flex-start;
 }
 
 .utility-navigation .icon {
@@ -59,8 +62,15 @@ nav ul li {
     border-bottom-left-radius: 0.25rem;
 }
 
-.utility-navigation-menu li:last-child a {
+.utility-navigation-menu li:last-child a,
+.utility-navigation-menu .logout-button {
     border-bottom-right-radius: 0.25rem;
+}
+
+.utility-navigation-menu .logout-button {
+    border-top: none;
+    border-left: none;
+    border-right: none;
 }
 
 @include breakpoints.phone-only() {
@@ -74,6 +84,7 @@ nav ul li {
         width: 25%;
     }
 }
+
 /*
 .global-header .container .navbar-menu {
     position: absolute;

--- a/resources/sass/themes/modules/_default.scss
+++ b/resources/sass/themes/modules/_default.scss
@@ -1,4 +1,3 @@
-
 input:focus {
     outline: 2px solid var(--royal-blue);
     box-shadow: 1px 1px 8px 1px var(--royal-blue);
@@ -27,7 +26,7 @@ input:focus::placeholder {
     background-color: inherit;
 }
 
-.global-header{
+.global-header {
     color: var(--white);
     background-color: var(--base-color);
 }
@@ -87,7 +86,7 @@ input:focus::placeholder {
 
 .logout-button:active,
 .logout-button:hover {
-    border-bottom-color: var(--black);
+    border-bottom-color: var(--dark-gray);
 }
 
 .site-header .dropdown-toggle {
@@ -138,6 +137,7 @@ input[type='search']:focus {
 .minimal .site-header {
     background-color: var(--base-color);
 }
+
 .site-header {
     border-top: 3px solid var(--yellow-green);
 }


### PR DESCRIPTION
Per #13 the nav buttons don't line up correctly with the top of the global navigation div, because we are trying to undo the padding, and because the login button is taller than the other links.

This PR moves the padding from the global navigation container into child elements, except for the utility navigation, so we can align that to the top instead. Then, we remove most of the login button borders so that its height matches the other links.

### Screenshots
<img width="568" alt="login-hover" src="https://github.com/user-attachments/assets/70e4bfa2-1990-49d8-80c1-b02c463be2ae" />
<img width="738" alt="new-post-hover" src="https://github.com/user-attachments/assets/ca517668-74a3-4915-bcc0-5b7a56bde03d" />
<img width="1180" alt="logout-hover" src="https://github.com/user-attachments/assets/89c9bd63-3e79-4a0a-b188-b3e8d58a876a" />
