### PR TITLE
Add information for accessing admin panel to Docker

### DIFF
--- a/DEVELOPING-docker.md
+++ b/DEVELOPING-docker.md
@@ -78,3 +78,24 @@ You can also start the services individually in separate terminals with:
 - `docker compose run --rm --service-ports dev-backend`
 
 The development server should then be accessible at http://www.metafilter.test:8000/, with hot reloading on frontend changes.
+
+
+## Create an admin account
+
+The `AdminSeeder` can import an account from JSON and assign it the `moderator` role. Create a JSON at `storage/app/imports/metafilter-admins.json`:
+
+```json
+[
+  {
+    "name": "Dev Eloper",
+    "username": "developer",
+    "email": "developer@metafilter.test",
+    "password": "password",
+    "legacy_id": null
+  }
+]
+```
+
+Then, run the seeder using `docker compose run --rm artisan mefi:run-admin-seeder`.
+
+After logging in with an admin account, you should be able to browse to http://www.metafilter.test/admin and see the admin screens.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\RoleNameEnum;
 use App\Presenters\UserPresenter;
 use App\States\User\UserState;
 use Coderflex\LaravelPresenter\Concerns\CanPresent;
@@ -118,6 +119,6 @@ final class User extends Authenticatable implements
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return false;
+        return $this->hasRole(RoleNameEnum::MODERATOR->value);
     }
 }

--- a/database/seeders/Development/AdminSeeder.php
+++ b/database/seeders/Development/AdminSeeder.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace Database\Seeders\Development;
 
+use App\Enums\RoleNameEnum;
 use App\Enums\UserStateEnum;
 use App\Models\User;
 use App\Traits\AdminSeederTrait;
+use App\Traits\PermissionAndRoleTrait;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 
 final class AdminSeeder extends Seeder
 {
     use AdminSeederTrait;
+    use PermissionAndRoleTrait;
 
     public function run(): void
     {
         $admins = $this->getAdminsFromJson();
 
         collect($admins)->each(function ($admin) {
-            (new User())->updateOrCreate([
+            $user = (new User())->updateOrCreate([
                 'email' => $admin['email'],
             ], [
                 'name' => $admin['name'],
@@ -29,6 +32,12 @@ final class AdminSeeder extends Seeder
                 'password' => Hash::make('password'),
                 'state' => UserStateEnum::Active->value,
             ]);
+
+            if ($user) {
+                $user->assignRole(RoleNameEnum::MODERATOR->value);
+            }
         });
+
+        $this->forgetCachedPermissions();
     }
 }

--- a/docker/Dockerfile.php
+++ b/docker/Dockerfile.php
@@ -22,7 +22,8 @@ RUN sed -i "s/user = www-data/user = laravel/g" /usr/local/etc/php-fpm.d/www.con
 RUN sed -i "s/group = www-data/group = laravel/g" /usr/local/etc/php-fpm.d/www.conf
 RUN echo "php_admin_flag[log_errors] = on" >> /usr/local/etc/php-fpm.d/www.conf
 
-RUN docker-php-ext-install pdo pdo_mysql
+RUN apk add --no-cache icu-dev
+RUN docker-php-ext-install pdo pdo_mysql intl
 
 RUN mkdir -p /usr/src/php/ext/redis \
     && curl -L https://github.com/phpredis/phpredis/archive/refs/tags/6.1.0.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \


### PR DESCRIPTION
Accessing the Filament admin panels required additional setup in the Docker image as the `intl` extension also needs to be built.

Developers also need to create a JSON describing the user accounts they wish to bless with moderator privileges - added some instructions on how to get this to work.