### PR TITLE
Fix for #43 Previous & Next Links use background color in dark mode

### DIFF
--- a/resources/sass/themes/modules/_themeable.scss
+++ b/resources/sass/themes/modules/_themeable.scss
@@ -231,7 +231,7 @@ a.next:link .title,
 a.next:visited .title,
 a.previous:link .title,
 a.previous:visited .title {
-    color: var(--base-color);
+    color: light-dark(var(--base-color), var(--white));
 }
 
 a.next:active .title,


### PR DESCRIPTION
Fix for [issue #43](https://github.com/MetaFilter/MetaFilter2024/issues/43) , Previous & Next Links use background color in dark mode

![Screenshot from 2025-06-15 20-55-31](https://github.com/user-attachments/assets/16959ed4-7a3c-4af1-85ae-863b2d753183)
