### PR TITLE
Post and snippet editing in admin site

### DIFF
--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -22,6 +22,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Table;
 use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
 
 final class PostResource extends Resource
@@ -42,16 +43,11 @@ final class PostResource extends Resource
                     ->required()
                     ->maxLength(self::INPUT_MAX_LENGTH)
                     ->unique(Post::class, 'slug', ignoreRecord: true),
-                TextInput::make('legacy_id')
-                    ->numeric(),
                 Textarea::make('body')
                     ->required()
                     ->columnSpanFull(),
                 Textarea::make('more_inside')
                     ->columnSpanFull(),
-                TextInput::make('state')
-                    ->required()
-                    ->maxLength(self::INPUT_MAX_LENGTH),
                 Select::make('subsite_id')
                     ->relationship('subsite', 'name')
                     ->required(),
@@ -60,24 +56,13 @@ final class PostResource extends Resource
                     ->searchable()
                     ->preload()
                     ->required(),
-                TextInput::make('uuid')
-                    ->label('UUID')
-                    ->maxLength(36),
                 DateTimePicker::make('published_at'),
-                Toggle::make('is_published')
-                    ->required(),
-                Toggle::make('is_current')
-                    ->required(),
-                TextInput::make('publisher_type')
-                    ->maxLength(self::INPUT_MAX_LENGTH),
-                TextInput::make('publisher_id')
-                    ->numeric(),
             ]);
     }
 
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()->withDrafts();
+        return Post::current();
     }
 
     public static function table(Table $table): Table
@@ -95,15 +80,12 @@ final class PostResource extends Resource
                     ->boolean()
                     ->label('Published')
                     ->sortable(),
-                TextColumn::make('state')
-                    ->badge()
-                    ->searchable()
-                    ->sortable(),
                 TextColumn::make('subsite.name')
                     ->label('Subsite')
                     ->sortable(),
                 TextColumn::make('user.name')
                     ->label('Author')
+                    ->searchable()
                     ->sortable(),
                 TextColumn::make('published_at')
                     ->dateTime()
@@ -118,7 +100,11 @@ final class PostResource extends Resource
                 Filter::make('hide_drafts')
                     ->label('Hide drafts')
                     ->baseQuery(fn(Builder $query): Builder => $query->withoutDrafts())
-                    ->default(true),
+                    ->default(false),
+                SelectFilter::make('subsite_id')
+                    ->relationship('subsite', 'name')
+                    ->searchable()
+                    ->preload(),
             ])
             ->actions([
                 EditAction::make(),

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -21,6 +21,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Table;
+use Filament\Tables\Filters\Filter;
 use Illuminate\Database\Eloquent\Builder;
 
 final class PostResource extends Resource
@@ -114,7 +115,10 @@ final class PostResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Filter::make('hide_drafts')
+                    ->label('Hide drafts')
+                    ->baseQuery(fn(Builder $query): Builder => $query->withoutDrafts())
+                    ->default(true),
             ])
             ->actions([
                 EditAction::make(),

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -19,7 +19,9 @@ use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 final class PostResource extends Resource
 {
@@ -37,7 +39,8 @@ final class PostResource extends Resource
                     ->maxLength(self::INPUT_MAX_LENGTH),
                 TextInput::make('slug')
                     ->required()
-                    ->maxLength(self::INPUT_MAX_LENGTH),
+                    ->maxLength(self::INPUT_MAX_LENGTH)
+                    ->unique(Post::class, 'slug', ignoreRecord: true),
                 TextInput::make('legacy_id')
                     ->numeric(),
                 Textarea::make('body')
@@ -53,6 +56,8 @@ final class PostResource extends Resource
                     ->required(),
                 Select::make('user_id')
                     ->relationship('user', 'name')
+                    ->searchable()
+                    ->preload()
                     ->required(),
                 TextInput::make('uuid')
                     ->label('UUID')
@@ -69,18 +74,44 @@ final class PostResource extends Resource
             ]);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->withDrafts();
+    }
+
     public static function table(Table $table): Table
     {
         return $table
             ->columns([
                 TextColumn::make('title')
-                    ->searchable(),
+                    ->searchable()
+                    ->sortable()
+                    ->limit(50),
+                TextColumn::make('slug')
+                    ->searchable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                IconColumn::make('is_published')
+                    ->boolean()
+                    ->label('Published')
+                    ->sortable(),
+                TextColumn::make('state')
+                    ->badge()
+                    ->searchable()
+                    ->sortable(),
                 TextColumn::make('subsite.name')
-                    ->numeric()
+                    ->label('Subsite')
                     ->sortable(),
                 TextColumn::make('user.name')
-                    ->numeric()
+                    ->label('Author')
                     ->sortable(),
+                TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -12,7 +12,6 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\BulkActionGroup;

--- a/app/Filament/Resources/PostResource/Pages/EditPost.php
+++ b/app/Filament/Resources/PostResource/Pages/EditPost.php
@@ -20,7 +20,7 @@ final class EditPost extends EditRecord
             DeleteAction::make(),
             Action::make('publish')
             ->label('Publish')
-            ->visible(fn (Post $record) => $record->is_published === false)
+            ->visible(fn(Post $record) => $record->is_published === false)
             ->action(function (Post $record) {
                 $record->setLive();
                 $record->save();
@@ -30,7 +30,7 @@ final class EditPost extends EditRecord
             }),
             Action::make('unpublish')
             ->label('Unpublish')
-            ->visible(fn (Post $record) => $record->is_published === true)
+            ->visible(fn(Post $record) => $record->is_published === true)
             ->action(function (Post $record) {
                 $record->is_published = false;
                 $record->save();

--- a/app/Filament/Resources/PostResource/Pages/EditPost.php
+++ b/app/Filament/Resources/PostResource/Pages/EditPost.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\Resources\PostResource\Pages;
 
 use App\Filament\Resources\PostResource;
+use App\Models\Post;
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
@@ -16,6 +18,27 @@ final class EditPost extends EditRecord
     {
         return [
             DeleteAction::make(),
+            Action::make('publish')
+            ->label('Publish')
+            ->visible(fn (Post $record) => $record->is_published === false)
+            ->action(function (Post $record) {
+                $record->setLive();
+                $record->save();
+            })
+            ->after(function () {
+                $this->refreshFormData(['is_published', 'published_at']);
+            }),
+            Action::make('unpublish')
+            ->label('Unpublish')
+            ->visible(fn (Post $record) => $record->is_published === true)
+            ->action(function (Post $record) {
+                $record->is_published = false;
+                $record->save();
+            })
+            ->after(function () {
+                $this->refreshFormData(['is_published', 'published_at']);
+            }),
+
         ];
     }
 }

--- a/app/Filament/Resources/SnippetResource.php
+++ b/app/Filament/Resources/SnippetResource.php
@@ -9,6 +9,8 @@ use App\Filament\Resources\SnippetsResource\Pages\EditSnippets;
 use App\Filament\Resources\SnippetsResource\Pages\ListSnippets;
 use App\Models\Snippet;
 use Filament\Forms\Form;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
@@ -21,11 +23,18 @@ final class SnippetResource extends Resource
     protected static ?string $model = Snippet::class;
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
+    public const int INPUT_MAX_LENGTH = 255;
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                //
+                TextInput::make('title')
+                    ->required()
+                    ->maxLength(self::INPUT_MAX_LENGTH),
+                RichEditor::make('body')
+                    ->required()
+                    ->columnSpanFull(),
             ]);
     }
 

--- a/app/Filament/Resources/SnippetsResource/Pages/EditSnippets.php
+++ b/app/Filament/Resources/SnippetsResource/Pages/EditSnippets.php
@@ -6,7 +6,7 @@ namespace App\Filament\Resources\SnippetsResource\Pages;
 
 use App\Filament\Resources\SnippetResource;
 use Filament\Resources\Pages\EditRecord;
-use Filament\Tables\Actions\DeleteAction;
+use Filament\Actions\DeleteAction;
 
 final class EditSnippets extends EditRecord
 {

--- a/app/Livewire/Contact/ContactMessageForm.php
+++ b/app/Livewire/Contact/ContactMessageForm.php
@@ -1,5 +1,3 @@
-<?php
-
 declare(strict_types=1);
 
 namespace App\Livewire\Contact;

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -85,17 +85,17 @@ final class Comment extends BaseModel
 
     // Relationships
 
-    public function bookmarks(): int
+    public function bookmarkCount(): int
     {
         return Bookmark::count($this);
     }
 
-    public function favorites(): int
+    public function favoriteCount(): int
     {
         return Favorite::count($this);
     }
 
-    public function flags(): int
+    public function flagCount(): int
     {
         return Flag::count($this);
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -72,6 +72,11 @@ final class Post extends BaseModel implements CanPresent, HasMedia
         'published_at',
         'is_published',
         'state',
+        'slug',
+        'uuid',
+        'is_current',
+        'publisher_type',
+        'publisher_id',
     ];
 
     protected static array $marks = [

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\PostStateEnum;
 use App\Presenters\PostPresenter;
 use Coderflex\LaravelPresenter\Concerns\CanPresent;
 use Coderflex\LaravelPresenter\Concerns\UsesPresenters;
@@ -71,9 +72,7 @@ final class Post extends BaseModel implements CanPresent, HasMedia
         'user_id',
         'published_at',
         'is_published',
-        'state',
         'slug',
-        'uuid',
         'is_current',
         'publisher_type',
         'publisher_id',
@@ -88,6 +87,18 @@ final class Post extends BaseModel implements CanPresent, HasMedia
     protected array $presenters = [
         'default' => PostPresenter::class,
     ];
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (Post $post) {
+            // Set default state if not provided
+            if (empty($post->state)) {
+                $post->state = PostStateEnum::Draft->value;
+            }
+        });
+    }
 
     public function toSearchableArray(): array
     {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -151,17 +151,17 @@ final class Post extends BaseModel implements CanPresent, HasMedia
         return $this->hasMany(Comment::class);
     }
 
-    public function bookmarks(): int
+    public function bookmarkCount(): int
     {
         return Bookmark::count($this);
     }
 
-    public function favorites(): int
+    public function favoriteCount(): int
     {
         return Favorite::count($this);
     }
 
-    public function flags(): int
+    public function flagCount(): int
     {
         return Flag::count($this);
     }

--- a/app/Models/Snippet.php
+++ b/app/Models/Snippet.php
@@ -22,7 +22,7 @@ final class Snippet extends BaseModel
     // Properties
 
     protected $fillable = [
-        // Should it be possible to target a specific subsite?
+        // TODO: Should it be possible to target a specific subsite?
         'title',
         'body',
     ];

--- a/app/Models/Snippet.php
+++ b/app/Models/Snippet.php
@@ -22,6 +22,7 @@ final class Snippet extends BaseModel
     // Properties
 
     protected $fillable = [
+        // Should it be possible to target a specific subsite?
         'title',
         'body',
     ];

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Enums\RoleNameEnum;
 use App\Models\User;
 use App\Models\Post;
 use Illuminate\Auth\Access\HandlesAuthorization;
@@ -19,7 +20,7 @@ final class PostPolicy
 
     public function view(User $user, Post $post): bool
     {
-        if ($user->hasRole(['admin']) || $post->user_id === $user->id) {
+        if ($user->hasRole([RoleNameEnum::MODERATOR->value]) || $post->user_id === $user->id) {
             return true;
         }
 
@@ -34,7 +35,7 @@ final class PostPolicy
 
     public function update(User $user, Post $post): bool
     {
-        if ($user->hasRole(['admin']) || $post->user_id === $user->id) {
+        if ($user->hasRole([RoleNameEnum::MODERATOR->value]) || $post->user_id === $user->id) {
             return true;
         }
 

--- a/database/migrations/2025_06_19_180714_update_posts_slug_unique_constraint_to_partial.php
+++ b/database/migrations/2025_06_19_180714_update_posts_slug_unique_constraint_to_partial.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            // Drop the existing unique constraint on slug
+            $table->dropUnique(['slug']);
+        });
+
+        // Uses IF(is_published = 1, 1, NULL) so only published records enforce uniqueness.
+        DB::statement('CREATE UNIQUE INDEX posts_slug_published_unique ON posts (slug, (IF(is_published = 1, 1, NULL)))');
+    }
+
+    public function down(): void
+    {
+        // Drop the functional unique index
+        DB::statement('DROP INDEX posts_slug_published_unique ON posts');
+        
+        Schema::table('posts', function (Blueprint $table) {
+            // Restore the original unique constraint
+            $table->unique('slug');
+        });
+    }
+};

--- a/database/migrations/2025_06_19_180714_update_posts_slug_unique_constraint_to_partial.php
+++ b/database/migrations/2025_06_19_180714_update_posts_slug_unique_constraint_to_partial.php
@@ -7,8 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('posts', function (Blueprint $table) {
@@ -24,7 +23,7 @@ return new class extends Migration
     {
         // Drop the functional unique index
         DB::statement('DROP INDEX posts_slug_published_unique ON posts');
-        
+
         Schema::table('posts', function (Blueprint $table) {
             // Restore the original unique constraint
             $table->unique('slug');

--- a/resources/views/livewire/posts/post-comments-component.blade.php
+++ b/resources/views/livewire/posts/post-comments-component.blade.php
@@ -6,8 +6,8 @@
 
                 @include('comments.partials.comment-footer', [
                     'comment' => $comment,
-                    'favoritesCount' => $comment->favorites()->count(),
-                    'flagsCount' => $comment->flags()->count(),
+                    'favoritesCount' => $comment->favoriteCount(),
+                    'flagsCount' => $comment->flagCount(),
                     'flagReasons' => $flagReasons,
                 ])
             </article>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -43,7 +43,7 @@
         @include('posts.partials.post-show-footer', [
             'post' => $post,
             'commentsCount' => $post->comments()->count(),
-            'favoritesCount' => $post->favorites(),
+            'favoritesCount' => $post->favoriteCount(),
         ])
     </article>
 


### PR DESCRIPTION
Editing posts in the admin site was not straightforward as the resource was not set up to transfer all the necessary fields, and also the unique constraint on `slug` would prevent revisions of a post from being saved, due to the way we maintain prior versions in the same table.

Editing snippets was also not supported as we needed to implement a form.

## Screenshots

**Snippet editing**
![snippets](https://github.com/user-attachments/assets/f1a52d65-3547-4c2b-a62a-1032fee5ad3d)

**Post editing**
![posts](https://github.com/user-attachments/assets/f8b0ab58-26c7-4f91-ac5c-fd7e2d580664)
