### PR TITLE
Github action to confirm PHP formatting correct

### DIFF
--- a/.github/workflows/php-formatting.yml
+++ b/.github/workflows/php-formatting.yml
@@ -1,0 +1,34 @@
+name: PHP Formatting Check
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  php-formatting:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+    - name: Run Laravel Pint formatting check
+      run: |
+        # Run pint and capture changes
+        docker run --rm \
+          --entrypoint /bin/sh \
+          -v ${{ github.workspace }}:/app \
+          bitnami/laravel:11 \
+          -c "composer install --no-autoloader && ./vendor/bin/pint"
+
+        # Check if there are any changes after running pint
+        if [[ -n $(git diff --name-only) ]]; then
+          echo "❌ PHP formatting issues detected. The following files need formatting:"
+          git diff --name-only
+          echo ""
+          echo "Please run 'php artisan pint' locally and commit the changes."
+          exit 1
+        else
+          echo "✅ All PHP files are properly formatted."
+        fi

--- a/app/Livewire/Posts/PostFormComponent.php
+++ b/app/Livewire/Posts/PostFormComponent.php
@@ -52,10 +52,10 @@ final class PostFormComponent extends Component
     #[On(LivewireEventEnum::EditorUpdated->value)]
     public function saveEditorContent($editorId, $content): void
     {
-        if ($editorId == "post-body") {
+        if ($editorId === 'post-body') {
             $this->body = $content;
         }
-        if ($editorId == "more-inside") {
+        if ($editorId === 'more-inside') {
             $this->more_inside = $content;
         }
     }


### PR DESCRIPTION
This PR adds a Github action that runs `php artisan pint` on the proposed changes and fails if there are formatting changes required.

This is a step towards resolving #36, but doesn't include the pre-push hook idea, as I am not sure whether we can easily make those account for developers working with Docker vs having `php` installed locally.