### PR TITLE
Remove word count

### DIFF
--- a/app/Livewire/Comments/CommentComponent.php
+++ b/app/Livewire/Comments/CommentComponent.php
@@ -26,7 +26,6 @@ final class CommentComponent extends Component
     public int $flagCount = 0;
     public string $flagIconFilename = 'flag';
     public string $flagButtonText = '';
-    public int $wordCount = 0;
     public bool $userFlagged = false;
 
     // State
@@ -49,8 +48,6 @@ final class CommentComponent extends Component
         $this->post = $post;
 
         $this->body = $comment->body;
-
-        $this->wordCount = str_word_count($comment->body);
 
         $this->user = auth()->user() ?? null;
 
@@ -98,7 +95,6 @@ final class CommentComponent extends Component
     {
         $this->reset([
             'body',
-            'wordCount',
         ]);
 
         $this->stopEditing();

--- a/app/Livewire/Comments/CommentShowComponent.php
+++ b/app/Livewire/Comments/CommentShowComponent.php
@@ -29,13 +29,11 @@ final class CommentShowComponent extends Component
     public bool $userFavorited = false;
     public bool $userFlagged = false;
     public bool $userWatching = false;
-    public int $wordCount = 0;
 
     public function mount(Comment $comment): void
     {
         $this->authorizedUserId = $this->getAuthorizedUserId();
         $this->comment = $comment;
-        $this->wordCount = str_word_count($comment->body);
     }
 
     public function render(): View

--- a/resources/views/livewire/comments/comment-component.blade.php
+++ b/resources/views/livewire/comments/comment-component.blade.php
@@ -2,11 +2,6 @@
     {!! $comment->body !!}
 
     <footer class="comment-footer">
-        <p>
-            <x-icons.icon-component filename="card-text"/>
-            {{ $wordCount . ' ' .  trans('words') }}
-        </p>
-
         <x-members.profile-link-component :user="$comment->user"/>
 
         @include('comments.partials.comment-timestamp', [

--- a/resources/views/livewire/comments/comment-reactions-component.blade.php
+++ b/resources/views/livewire/comments/comment-reactions-component.blade.php
@@ -2,7 +2,7 @@
     @foreach ($this->types as $type)
         {{-- TODO: Move types to a config array to include text like mark as a favorite and the icon --}}
         <button wire:click="toggleReaction('{{ $type }}')">
-            {{ $type }} ({{ $reactions->where('type', '=', $type)->count() }})
+            {{ $type }} ({{ $reactions->where('type', '=', $type)->count() }}) + more
         </button>
     @endforeach
 </div>

--- a/resources/views/livewire/comments/comment-show-component.blade.php
+++ b/resources/views/livewire/comments/comment-show-component.blade.php
@@ -2,11 +2,6 @@
     {{ $comment->body }}
 
     <footer class="comment-footer">
-        <p>
-            <x-icons.icon-component filename="card-text" />
-            {{ $wordCount . ' ' .  trans('words') }}
-        </p>
-
         <x-members.profile-link-component :user="$comment->user" />
 
         @include('comments.partials.comment-timestamp', [

--- a/resources/views/posts/partials/ld-json/show.blade.php
+++ b/resources/views/posts/partials/ld-json/show.blade.php
@@ -27,6 +27,5 @@
     "datePublished": "{{ $post->created_at }}",
     "dateModified": "{{ $post->updated_at }}",
     "articleBody": "{!! strip_tags($post->body) !!}",
-    "url": "{{ url()->current() }}",
-    "wordCount": "{{ str_word_count(strip_tags($post->body)) }}"
+    "url": "{{ url()->current() }}"
 @endsection


### PR DESCRIPTION
Fix for #49 that just removes word counting as it doesn't seem helpful, and currently isn't accurate anyway when considering that post and comment bodies may include HTML.