### PR TITLE
Redirect to canonical subsite/slug for post

### DIFF
--- a/app/Traits/SubsiteTrait.php
+++ b/app/Traits/SubsiteTrait.php
@@ -157,9 +157,9 @@ trait SubsiteTrait
         };
     }
 
-    public function getShowPostRouteName(): string
+    public function getShowPostRouteName(?string $subdomain = null): string
     {
-        $subdomain = $this->getSubdomain();
+        $subdomain ??= $this->getSubdomain();
 
         return match ($subdomain) {
             'ask' => 'ask.posts.show',

--- a/routes/subdomains/ask.php
+++ b/routes/subdomains/ask.php
@@ -33,7 +33,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('ask.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('ask.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/bestof.php
+++ b/routes/subdomains/bestof.php
@@ -9,6 +9,7 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('bestof.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('bestof.posts.show');
 });

--- a/routes/subdomains/fanfare.php
+++ b/routes/subdomains/fanfare.php
@@ -33,7 +33,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('fanfare.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('fanfare.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/irl.php
+++ b/routes/subdomains/irl.php
@@ -15,7 +15,8 @@ Route::middleware('auth')->group(function () {
         Route::get('', 'index')
             ->name(RouteNameEnum::IrlMyPostsIndex);
 
-        Route::get('{post}/{slug}', 'show')
+        Route::get('{post}/{slug?}', 'show')
+            ->whereNumber('post')
             ->name(RouteNameEnum::IrlMyPostsShow);
     });
 });
@@ -33,7 +34,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('irl.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('irl.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/jobs.php
+++ b/routes/subdomains/jobs.php
@@ -25,7 +25,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('jobs.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('jobs.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/metafilter.php
+++ b/routes/subdomains/metafilter.php
@@ -122,7 +122,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('metafilter.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('metafilter.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/metatalk.php
+++ b/routes/subdomains/metatalk.php
@@ -35,7 +35,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('metatalk.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('metatalk.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/music.php
+++ b/routes/subdomains/music.php
@@ -36,7 +36,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('music.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('music.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/podcast.php
+++ b/routes/subdomains/podcast.php
@@ -31,7 +31,8 @@ Route::controller(PostController::class)->group(function () {
     Route::get('', 'index')
         ->name('podcast.posts.index');
 
-    Route::get('{post}/{slug}', 'show')
+    Route::get('{post}/{slug?}', 'show')
+        ->whereNumber('post')
         ->name('podcast.posts.show');
 
     Route::middleware('auth')->group(function () {

--- a/routes/subdomains/projects.php
+++ b/routes/subdomains/projects.php
@@ -22,7 +22,8 @@ Route::controller(PostController::class)
         Route::get('', 'index')
             ->name('projects.posts.index');
 
-        Route::get('{post}/{slug}', 'show')
+        Route::get('{post}/{slug?}', 'show')
+            ->whereNumber('post')
             ->name('projects.posts.show');
 
         Route::middleware('auth')->group(function () {


### PR DESCRIPTION
As noted in #57 and #58, it would be good for the PostController to redirect to the canonical URL even when the slug is not provided, or is incorrect.
