### PR TITLE
Fix up comment form

### DIFF
--- a/app/Livewire/Comments/CommentComponent.php
+++ b/app/Livewire/Comments/CommentComponent.php
@@ -41,7 +41,7 @@ final class CommentComponent extends Component
     {
         $moderationType = $this->appearanceComment?->moderation_type ?? null;
 
-        $hasModeratorActions = $this->filterModeratorActions($this->childComments, $this->state === CommentStateEnum::Moderating)->isNotEmpty();
+        $hasModeratorActions = !empty($this->childComments) && $this->filterModeratorActions($this->childComments, $this->state === CommentStateEnum::Moderating)->isNotEmpty();
 
         // If there are no decorations to apply, just render the basic comment component.
         return view('livewire.comments.comment-component', [

--- a/app/Livewire/Comments/CommentFormComponent.php
+++ b/app/Livewire/Comments/CommentFormComponent.php
@@ -21,16 +21,16 @@ final class CommentFormComponent extends Component
 
     // Props
     #[Locked]
-    public int $postId;
+    public int $postId = 0;
 
     #[Locked]
-    public ?int $commentId;
+    public ?int $commentId = null;
 
     #[Locked]
-    public ?int $parentId;
+    public ?int $parentId = null;
 
     #[Locked]
-    public string $idSuffix;
+    public string $idSuffix = '';
 
     // Form data
     public string $body = '';
@@ -38,24 +38,18 @@ final class CommentFormComponent extends Component
     public string $message = '';
 
     // State
-    public bool $isEditing;
-    public bool $isReplying;
-    public bool $isModerating;
+    public bool $isEditing = false;
+    public bool $isReplying = false;
+    public bool $isModerating = false;
 
     // Data not persisted in the client-side snapshot
     protected ?Comment $comment;
 
     #[Computed]
-    public function isAdding(): bool
-    {
-        return !$this->isEditing && !$this->isReplying && !$this->isModerating;
-    }
-
-    #[Computed]
     public function isBodyEditable(): bool
     {
-        return $this->isAdding || $this->isEditing ||
-            ($this->isModerating && $this->moderationType === ModerationTypeEnum::Edit);
+        // The body is editable if not moderating, or if the moderator is editing the original comment.
+        return !$this->isModerating || $this->moderationType === ModerationTypeEnum::Edit;
     }
 
     #[Computed]
@@ -103,15 +97,11 @@ final class CommentFormComponent extends Component
 
     public function render(): View
     {
-        $isAdding = !$this->isEditing && !$this->isReplying && !$this->isModerating;
-        $isBodyEditable = $isAdding || $this->isEditing ||
-            ($this->isModerating && $this->moderationType === ModerationTypeEnum::Edit);
         $data = [
             'bodyLabel' => trans('Comment'),
             'messageLabel' => trans('Moderation message'),
             'buttonText' => trans('Add Comment'),
-            'isAdding' => $isAdding,
-            'isBodyEditable' => $isBodyEditable,
+            'isBodyEditable' => $this->isBodyEditable,
             'bodyEditorId' => $this->bodyEditorId,
             'messageEditorId' => $this->messageEditorId,
         ];

--- a/resources/views/livewire/comments/comment-component.blade.php
+++ b/resources/views/livewire/comments/comment-component.blade.php
@@ -92,7 +92,8 @@ use App\Enums\ModerationTypeEnum;
     @if ($isReplying === true)
         <livewire:comments.comment-form-component
             wire:key="reply-to-comment-{{ $commentId }}"
-            :comment="$comment"
+            :post-id="$comment->post_id"
+            :parent-id="$commentId"
             is-replying="true"
             @comment-updated="closeForm()"
             @comment-stored="closeForm()"


### PR DESCRIPTION
The comment form is not working correctly when adding a new comment to a post, or replying to a comment. Comment replies are currently not shown, but the form was allowing comments to be posted to the database prior to recent changes from #66, #67 and #68.

Adding new comments was not working as the comment form component is only passed a `$postId`, but expected that `$parentId` and `$childComments` could be accessed.

Showing the comment reply form was not working as the `$isBodyEditable` logic was incorrect: it simply needed to exclude the original comment field from forms intended to gather moderator messages that were not part of a moderator editing another member's comment.