### PR TITLE
Fix comment count to match # of comments

### DIFF
--- a/app/Livewire/Posts/PostIndexItemComponent.php
+++ b/app/Livewire/Posts/PostIndexItemComponent.php
@@ -21,7 +21,7 @@ final class PostIndexItemComponent extends Component
     {
         $this->authorizedUserId = $this->getAuthorizedUserId();
         $this->post = $post;
-        $this->commentCount = $post->comments()->count();
+        $this->commentCount = $post->commentsCount();
     }
 
     public function render(): View

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -146,7 +146,7 @@ final class Post extends BaseModel implements CanPresent, HasMedia
     public function commentsCount(): int
     {
         // Only count comments by regular users, not moderator actions
-        return $this->hasMany(Comment::class)->whereNull("moderation_type")->count();
+        return $this->hasMany(Comment::class)->whereNull('moderation_type')->count();
     }
 
     public function bookmarkCount(): int

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -143,6 +143,12 @@ final class Post extends BaseModel implements CanPresent, HasMedia
         return $this->hasMany(Comment::class);
     }
 
+    public function commentsCount(): int
+    {
+        // Only count comments by regular users, not moderator actions
+        return $this->hasMany(Comment::class)->whereNull("moderation_type")->count();
+    }
+
     public function bookmarkCount(): int
     {
         return Bookmark::count($this);

--- a/resources/views/posts/partials/post-index-footer.blade.php
+++ b/resources/views/posts/partials/post-index-footer.blade.php
@@ -9,6 +9,6 @@
         href="{{ $post->present()->url }}#comments"
         title="{{ trans('Comments') }}">
         <x-icons.icon-component filename="chat" />
-        {{ $post->comments()->count() > 0 ?: 0 }}
+        {{ $post->commentsCount() }}
     </a>
 </footer>

--- a/resources/views/posts/partials/post-show-footer.blade.php
+++ b/resources/views/posts/partials/post-show-footer.blade.php
@@ -15,7 +15,7 @@
 
     <span>
         <x-icons.icon-component filename="chat" />
-        {{ $commentsCount > 0 ?: 0 }}
+        {{ $commentsCount }}
     </span>
 
     @if (isset($favoritesCount) && $favoritesCount > 0)

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -42,7 +42,7 @@
 
         @include('posts.partials.post-show-footer', [
             'post' => $post,
-            'commentsCount' => $post->comments()->count(),
+            'commentsCount' => $post->commentsCount(),
             'favoritesCount' => $post->favoriteCount(),
         ])
     </article>


### PR DESCRIPTION
This pull request hopefully closes #70.

This operand ?: I guess is a shorthand for a ternary expression that "will evaluate as the first operand if it true, and the third operand otherwise" ([link](https://stackoverflow.com/questions/1276909/php-syntax-question-what-does-the-question-mark-and-colon-mean)) 

For statements like ` $commentsCount > 0 ?: 0`  when the comment count was greater than 0, then the displayed comment count ended up being 1 for true.

I made a new method for the Post model that just returns a count of non-moderation action comments, because otherwise the comment count includes whenever a moderator adds, edits, blurs etc. a comment.

This pull request should fix the comment count for the homepage, on the page for a single post, and the archive page at /archives/YYYY/MM/DD (ex. archives/2025/08/12)

(The comment count on the page for a single post will be initially accurate, but the number is not updated when a new comment is posted. Only updates on reload)