### PR TITLE
Fix logout on subsites

### DIFF
--- a/resources/views/layouts/navigation/partials/logout-form.blade.php
+++ b/resources/views/layouts/navigation/partials/logout-form.blade.php
@@ -1,5 +1,5 @@
 <form
-    action="/logout"
+    action="{{ route('logout') }}"
     class="logout-form"
     method="POST"
 >

--- a/resources/views/vendor/larecipe/partials/nav.blade.php
+++ b/resources/views/vendor/larecipe/partials/nav.blade.php
@@ -57,7 +57,7 @@
                     </larecipe-button>
 
                     <template slot="list">
-                        <form action="/logout" method="POST">
+                        <form action="{{ route('logout') }}" method="POST">
                             {{ csrf_field() }}
 
                             <button type="submit" class="py-2 px-4 text-white bg-danger inline-flex"><i class="fa fa-power-off mr-2"></i> Logout</button>


### PR DESCRIPTION
This pull request will hopefully close #77  unable to log out on subsites. 

I am able to log out from any subsite just fine on local. I am honestly not 100% sure why logout works on local as opposed to on staging.
I do know that using the developer tools to change the action for the logout button on staging from /logout to https://www.metastaging.net/logout results in a successful logout even from subsites. Right click the "logout" button in a subsite and edit the action as shown.

<img width="498" height="176" alt="Screenshot from 2025-08-25 21-37-04" src="https://github.com/user-attachments/assets/e6ca4a7b-da5a-40e3-8fd4-7e1c0a23757d" />

<img width="711" height="212" alt="Screenshot from 2025-08-25 21-36-52" src="https://github.com/user-attachments/assets/28d30f05-1ec9-4382-801e-b678195aaccb" />

Something about the local setup allows for posting /logout to a subsite URL, but staging does not.

I am pretty sure that changing the logout action from a relative URL to a named route will solve the problem.

