### PR TITLE
Fix permalinks to comments

### DIFF
--- a/resources/views/comments/partials/comment-timestamp.blade.php
+++ b/resources/views/comments/partials/comment-timestamp.blade.php
@@ -1,5 +1,5 @@
 <time datetime="{{ $comment->created_at->format('Y-m-d H:i:d') }}">
-    <a href="#{{ $comment->id }}" class="footer-info" title="{{ trans('Permanent link to this comment') }}">
+    <a href="#comment-{{ $comment->id }}" class="footer-info" title="{{ trans('Permanent link to this comment') }}">
         <x-icons.icon-component filename="clock" class="icon-small" />
         {{ $comment->created_at->format('g:i a') }}
     </a>

--- a/resources/views/livewire/comments/comment-component.blade.php
+++ b/resources/views/livewire/comments/comment-component.blade.php
@@ -3,6 +3,7 @@ use App\Enums\ModerationTypeEnum;
 @endphp
 
 <article class="comment @if ($isRemoved) moderator-removed @endif"
+    id="comment-{{ $commentId }}"
     data-comment-id="{{ $commentId }}"
     @if (!$isRemoved)
         data-member-id="{{ $comment->user->id }}"

--- a/resources/views/livewire/comments/moderator-comment.blade.php
+++ b/resources/views/livewire/comments/moderator-comment.blade.php
@@ -1,4 +1,4 @@
-<div class="moderator-message moderation-action {{ $moderationClass }}">
+<div class="moderator-message moderation-action {{ $moderationClass }}" id="comment-{{ $comment->id }}">
     <aside class="moderation-action">
         {{ trans($moderationAction) }}
     </aside>


### PR DESCRIPTION
This pull request should close #69.

I've added the comment ID to the article element surrounding each comment (regular comments and moderator actions), so the anchor links work

There's already a data-comment-id on that element, so I could have jumped to the comments with Javascript instead, but that seemed unnecessarily complicated and I couldn't find any code that was already trying to do that.

I added comment- to the anchor link (from #{id of comment} to #comment-{id of comment}) because I was worried about the off chance that something else on the page would also happen to have the same id.