### PR TITLE
docs: fix 3 missing possessive apostrophes in config comments

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -54,7 +54,7 @@ return [
 
         /*
          * When using the "HasPermissions" trait from this package, we need to know which
-         * table should be used to retrieve your models permissions. We have chosen a
+         * table should be used to retrieve your models' permissions. We have chosen a
          * basic default value but you may easily change it to any table you like.
          */
 
@@ -62,7 +62,7 @@ return [
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
-         * table should be used to retrieve your models roles. We have chosen a
+         * table should be used to retrieve your models' roles. We have chosen a
          * basic default value but you may easily change it to any table you like.
          */
 
@@ -70,7 +70,7 @@ return [
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
-         * table should be used to retrieve your roles permissions. We have chosen a
+         * table should be used to retrieve your roles' permissions. We have chosen a
          * basic default value but you may easily change it to any table you like.
          */
 


### PR DESCRIPTION
## Summary

Fix 3 missing possessive apostrophes in `config/permission.php` comments:

- "your models permissions" → "your models' permissions"
- "your models roles" → "your models' roles"
- "your roles permissions" → "your roles' permissions"

No functional changes — PHP config comments only.